### PR TITLE
Fix for select field placeholder

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,9 +39,12 @@ const textFieldMap = customMap(({ input: { onChange } }) => ({
 }));
 
 const selectFieldMap = customMap(
-  ({ input: { onChange, value }, multiple, options }) => {
-    if (options && options.length > 0) {
+  ({ input: { onChange, value }, multiple, options, placeholder }) => {
+    if (!placeholder && (options && options.length > 0)) {
       value = value ? value : multiple ? [options[0].value] : options[0].value;
+    }
+    if (placeholder) {
+      value = value === "" ? undefined : value;
     }
     return { dropdownMatchSelectWidth: true, value, style: { minWidth: 200 } };
   }


### PR DESCRIPTION
In my use case i wanted the placeholder to show up for Select Fields too but they were overwritten by the first option. Also if its an empty string which is the default value provided by redux-form then antd treats it as blank value.

This change works but not sure if it's the best way.