### PR TITLE
Split fields into individual files

### DIFF
--- a/es/components/CheckboxField.js
+++ b/es/components/CheckboxField.js
@@ -1,0 +1,21 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _checkbox = require("antd/lib/checkbox");
+
+var _checkbox2 = _interopRequireDefault(_checkbox);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+var _eventMap = require("../maps/eventMap");
+
+var _eventMap2 = _interopRequireDefault(_eventMap);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _BaseComponent2.default)(_checkbox2.default, _eventMap2.default);

--- a/es/components/CheckboxGroupField.js
+++ b/es/components/CheckboxGroupField.js
@@ -1,0 +1,33 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _checkbox = require("antd/lib/checkbox");
+
+var _checkbox2 = _interopRequireDefault(_checkbox);
+
+var _mapError = require("../maps/mapError");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var CheckboxGroup = _checkbox2.default.Group;
+
+var checkboxGroupMap = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _ref$input = _ref.input,
+      onChange = _ref$input.onChange,
+      _ref$input$value = _ref$input.value,
+      value = _ref$input$value === undefined ? [] : _ref$input$value;
+
+  value = (0, _mapError.defaultTo)(value, []);
+  return _extends({}, mapProps, { onChange: onChange, value: value });
+});
+
+exports.default = (0, _BaseComponent2.default)(CheckboxGroup, checkboxGroupMap);

--- a/es/components/DatePicker.js
+++ b/es/components/DatePicker.js
@@ -15,7 +15,7 @@ var _datePicker = require("antd/lib/date-picker");
 
 var _datePicker2 = _interopRequireDefault(_datePicker);
 
-var _mapError = require("./mapError");
+var _mapError = require("../maps/mapError");
 
 var _BaseComponent = require("./BaseComponent");
 

--- a/es/components/LazyTextField.js
+++ b/es/components/LazyTextField.js
@@ -1,0 +1,48 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _input = require("antd/lib/input");
+
+var _input2 = _interopRequireDefault(_input);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+var _mapError = require("../maps/mapError");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+// will trigger on change only onBlur
+// usefull for performance reasons
+var bluredFieldMap = function bluredFieldMap(_ref) {
+  var _ref$meta = _ref.meta;
+  _ref$meta = _ref$meta === undefined ? {} : _ref$meta;
+
+  var touched = _ref$meta.touched,
+      error = _ref$meta.error,
+      warning = _ref$meta.warning,
+      valid = _ref$meta.valid,
+      _ref$input = _ref.input,
+      value = _ref$input.value,
+      onChange = _ref$input.onChange,
+      props = _objectWithoutProperties(_ref, ["meta", "input"]);
+
+  return _extends({}, props, {
+    defaultValue: value,
+    onBlur: function onBlur(e) {
+      onChange(e.nativeEvent.target.value);
+    },
+    validateStatus: (0, _mapError.getValidateStatus)(touched, error, warning, valid),
+    help: touched && (error || warning)
+  });
+};
+
+exports.default = (0, _BaseComponent2.default)(_input2.default, bluredFieldMap);

--- a/es/components/NumberField.js
+++ b/es/components/NumberField.js
@@ -1,0 +1,21 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _inputNumber = require("antd/lib/input-number");
+
+var _inputNumber2 = _interopRequireDefault(_inputNumber);
+
+var _mapError = require("../maps/mapError");
+
+var _mapError2 = _interopRequireDefault(_mapError);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _BaseComponent2.default)(_inputNumber2.default, _mapError2.default);

--- a/es/components/RadioField.js
+++ b/es/components/RadioField.js
@@ -1,0 +1,19 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _eventMap = require("../maps/eventMap");
+
+var _eventMap2 = _interopRequireDefault(_eventMap);
+
+var _MultiSelect = require("./MultiSelect");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _BaseComponent2.default)(_MultiSelect.RadioField, _eventMap2.default);

--- a/es/components/SelectField.js
+++ b/es/components/SelectField.js
@@ -1,0 +1,36 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _mapError = require("../maps/mapError");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+var _MultiSelect = require("./MultiSelect");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var selectFieldMap = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _ref$input = _ref.input,
+      onChange = _ref$input.onChange,
+      value = _ref$input.value,
+      multiple = _ref.multiple,
+      options = _ref.options,
+      placeholder = _ref.placeholder;
+
+  if (!placeholder && options && options.length > 0) {
+    value = value ? value : multiple ? [options[0].value] : options[0].value;
+  }
+  if (placeholder) {
+    value = value === "" ? undefined : value;
+  }
+  return _extends({}, mapProps, { dropdownMatchSelectWidth: true, value: value, style: { minWidth: 200 } });
+});
+
+exports.default = (0, _BaseComponent2.default)(_MultiSelect.SelectField, selectFieldMap);

--- a/es/components/SliderField.js
+++ b/es/components/SliderField.js
@@ -1,0 +1,36 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _slider = require("antd/lib/slider");
+
+var _slider2 = _interopRequireDefault(_slider);
+
+var _mapError = require("../maps/mapError");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var sliderMap = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _ref$input = _ref.input,
+      onChange = _ref$input.onChange,
+      _ref$input$value = _ref$input.value,
+      value = _ref$input$value === undefined ? 0 : _ref$input$value,
+      range = _ref.range,
+      _ref$min = _ref.min,
+      min = _ref$min === undefined ? 0 : _ref$min,
+      _ref$max = _ref.max,
+      max = _ref$max === undefined ? 100 : _ref$max;
+
+  value = (0, _mapError.defaultTo)(value, range ? [min, max] : 0);
+  return _extends({}, mapProps, { onAfterChange: onChange, value: value });
+});
+
+exports.default = (0, _BaseComponent2.default)(_slider2.default, sliderMap);

--- a/es/components/SwitchField.js
+++ b/es/components/SwitchField.js
@@ -1,0 +1,28 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _switch = require("antd/lib/switch");
+
+var _switch2 = _interopRequireDefault(_switch);
+
+var _mapError = require("../maps/mapError");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var switchMap = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var value = _ref.input.value;
+  return _extends({}, mapProps, {
+    checked: value
+  });
+});
+
+exports.default = (0, _BaseComponent2.default)(_switch2.default, switchMap);

--- a/es/components/TextAreaField.js
+++ b/es/components/TextAreaField.js
@@ -1,0 +1,22 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _input = require("antd/lib/input");
+
+var _input2 = _interopRequireDefault(_input);
+
+var _textFieldMap = require("../maps/textFieldMap");
+
+var _textFieldMap2 = _interopRequireDefault(_textFieldMap);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var TextArea = _input2.default.TextArea;
+exports.default = (0, _BaseComponent2.default)(TextArea, _textFieldMap2.default);

--- a/es/components/TextField.js
+++ b/es/components/TextField.js
@@ -1,0 +1,21 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _input = require("antd/lib/input");
+
+var _input2 = _interopRequireDefault(_input);
+
+var _textFieldMap = require("../maps/textFieldMap");
+
+var _textFieldMap2 = _interopRequireDefault(_textFieldMap);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _BaseComponent2.default)(_input2.default, _textFieldMap2.default);

--- a/es/index.js
+++ b/es/index.js
@@ -5,8 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.customMap = exports.createComponent = exports.SliderField = exports.NumberField = exports.SwitchField = exports.TextAreaField = exports.TextField = exports.RadioField = exports.CheckboxField = exports.SelectField = exports.LazyTextField = exports.CheckboxGroupField = undefined;
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 var _DatePicker = require("./components/DatePicker");
 
 Object.keys(_DatePicker).forEach(function (key) {
@@ -19,150 +17,63 @@ Object.keys(_DatePicker).forEach(function (key) {
   });
 });
 
-var _checkbox = require("antd/lib/checkbox");
-
-var _checkbox2 = _interopRequireDefault(_checkbox);
-
-var _input = require("antd/lib/input");
-
-var _input2 = _interopRequireDefault(_input);
-
-var _slider = require("antd/lib/slider");
-
-var _slider2 = _interopRequireDefault(_slider);
-
-var _inputNumber = require("antd/lib/input-number");
-
-var _inputNumber2 = _interopRequireDefault(_inputNumber);
-
-var _switch = require("antd/lib/switch");
-
-var _switch2 = _interopRequireDefault(_switch);
-
 var _BaseComponent = require("./components/BaseComponent");
 
 var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
 
-var _MultiSelect = require("./components/MultiSelect");
+var _mapError = require("./maps/mapError");
 
-var _mapError = require("./components/mapError");
+var _CheckboxGroupField2 = require("./components/CheckboxGroupField");
 
-var _mapError2 = _interopRequireDefault(_mapError);
+var _CheckboxGroupField3 = _interopRequireDefault(_CheckboxGroupField2);
+
+var _LazyTextField2 = require("./components/LazyTextField");
+
+var _LazyTextField3 = _interopRequireDefault(_LazyTextField2);
+
+var _SelectField2 = require("./components/SelectField");
+
+var _SelectField3 = _interopRequireDefault(_SelectField2);
+
+var _CheckboxField2 = require("./components/CheckboxField");
+
+var _CheckboxField3 = _interopRequireDefault(_CheckboxField2);
+
+var _RadioField2 = require("./components/RadioField");
+
+var _RadioField3 = _interopRequireDefault(_RadioField2);
+
+var _TextField2 = require("./components/TextField");
+
+var _TextField3 = _interopRequireDefault(_TextField2);
+
+var _TextAreaField2 = require("./components/TextAreaField");
+
+var _TextAreaField3 = _interopRequireDefault(_TextAreaField2);
+
+var _SwitchField2 = require("./components/SwitchField");
+
+var _SwitchField3 = _interopRequireDefault(_SwitchField2);
+
+var _NumberField2 = require("./components/NumberField");
+
+var _NumberField3 = _interopRequireDefault(_NumberField2);
+
+var _SliderField2 = require("./components/SliderField");
+
+var _SliderField3 = _interopRequireDefault(_SliderField2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
-
-var TextArea = _input2.default.TextArea;
-
-var CheckboxGroup = _checkbox2.default.Group;
-
-var defaultTo = function defaultTo(value, d) {
-  if (!value && value !== 0) return d;
-  return value;
-};
-
-var eventMap = (0, _mapError.customMap)(function (mapProps, _ref) {
-  var _onChange = _ref.input.onChange;
-  return _extends({}, mapProps, {
-    onChange: function onChange(v) {
-      return _onChange(v.target.value);
-    }
-  });
-});
-
-var checkboxGroupMap = (0, _mapError.customMap)(function (mapProps, _ref2) {
-  var _ref2$input = _ref2.input,
-      onChange = _ref2$input.onChange,
-      _ref2$input$value = _ref2$input.value,
-      value = _ref2$input$value === undefined ? [] : _ref2$input$value;
-
-  value = defaultTo(value, []);
-  return _extends({}, mapProps, { onChange: onChange, value: value });
-});
-
-var sliderMap = (0, _mapError.customMap)(function (mapProps, _ref3) {
-  var _ref3$input = _ref3.input,
-      onChange = _ref3$input.onChange,
-      _ref3$input$value = _ref3$input.value,
-      value = _ref3$input$value === undefined ? 0 : _ref3$input$value,
-      range = _ref3.range,
-      _ref3$min = _ref3.min,
-      min = _ref3$min === undefined ? 0 : _ref3$min,
-      _ref3$max = _ref3.max,
-      max = _ref3$max === undefined ? 100 : _ref3$max;
-
-  value = defaultTo(value, range ? [min, max] : 0);
-  return _extends({}, mapProps, { onAfterChange: onChange, value: value });
-});
-var textFieldMap = (0, _mapError.customMap)(function (mapProps, _ref4) {
-  var _onChange2 = _ref4.input.onChange;
-  return _extends({}, mapProps, {
-    onChange: function onChange(v) {
-      return _onChange2(v.nativeEvent.target.value);
-    }
-  });
-});
-
-var selectFieldMap = (0, _mapError.customMap)(function (mapProps, _ref5) {
-  var _ref5$input = _ref5.input,
-      onChange = _ref5$input.onChange,
-      value = _ref5$input.value,
-      multiple = _ref5.multiple,
-      options = _ref5.options,
-      placeholder = _ref5.placeholder;
-
-  if (!placeholder && options && options.length > 0) {
-    value = value ? value : multiple ? [options[0].value] : options[0].value;
-  }
-  if (placeholder) {
-    value = value === "" ? undefined : value;
-  }
-  return _extends({}, mapProps, { dropdownMatchSelectWidth: true, value: value, style: { minWidth: 200 } });
-});
-
-var bluredFieldMap = function bluredFieldMap(_ref6) {
-  var _ref6$meta = _ref6.meta;
-  _ref6$meta = _ref6$meta === undefined ? {} : _ref6$meta;
-
-  var touched = _ref6$meta.touched,
-      error = _ref6$meta.error,
-      warning = _ref6$meta.warning,
-      valid = _ref6$meta.valid,
-      _ref6$input = _ref6.input,
-      value = _ref6$input.value,
-      onChange = _ref6$input.onChange,
-      props = _objectWithoutProperties(_ref6, ["meta", "input"]);
-
-  return _extends({}, props, {
-    defaultValue: value,
-    onBlur: function onBlur(e) {
-      onChange(e.nativeEvent.target.value);
-    },
-    validateStatus: (0, _mapError.getValidateStatus)(touched, error, warning, valid),
-    help: touched && (error || warning)
-  });
-};
-
-var switchMap = (0, _mapError.customMap)(function (mapProps, _ref7) {
-  var value = _ref7.input.value;
-  return _extends({}, mapProps, {
-    checked: value
-  });
-});
-
-var CheckboxGroupField = exports.CheckboxGroupField = (0, _BaseComponent2.default)(CheckboxGroup, checkboxGroupMap);
-
-// will trigger on change only onBlur
-// usefull for performance reasons
-var LazyTextField = exports.LazyTextField = (0, _BaseComponent2.default)(_input2.default, bluredFieldMap);
-var SelectField = exports.SelectField = (0, _BaseComponent2.default)(_MultiSelect.SelectField, selectFieldMap);
-var CheckboxField = exports.CheckboxField = (0, _BaseComponent2.default)(_checkbox2.default, eventMap);
-var RadioField = exports.RadioField = (0, _BaseComponent2.default)(_MultiSelect.RadioField, eventMap);
-var TextField = exports.TextField = (0, _BaseComponent2.default)(_input2.default, textFieldMap);
-var TextAreaField = exports.TextAreaField = (0, _BaseComponent2.default)(TextArea, textFieldMap);
-var SwitchField = exports.SwitchField = (0, _BaseComponent2.default)(_switch2.default, switchMap);
-var NumberField = exports.NumberField = (0, _BaseComponent2.default)(_inputNumber2.default, _mapError2.default);
-var SliderField = exports.SliderField = (0, _BaseComponent2.default)(_slider2.default, sliderMap);
+exports.CheckboxGroupField = _CheckboxGroupField3.default;
+exports.LazyTextField = _LazyTextField3.default;
+exports.SelectField = _SelectField3.default;
+exports.CheckboxField = _CheckboxField3.default;
+exports.RadioField = _RadioField3.default;
+exports.TextField = _TextField3.default;
+exports.TextAreaField = _TextAreaField3.default;
+exports.SwitchField = _SwitchField3.default;
+exports.NumberField = _NumberField3.default;
+exports.SliderField = _SliderField3.default;
 exports.createComponent = _BaseComponent2.default;
 exports.customMap = _mapError.customMap;

--- a/es/maps/eventMap.js
+++ b/es/maps/eventMap.js
@@ -1,0 +1,18 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _mapError = require("./mapError");
+
+exports.default = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _onChange = _ref.input.onChange;
+  return _extends({}, mapProps, {
+    onChange: function onChange(v) {
+      return _onChange(v.target.value);
+    }
+  });
+});

--- a/es/maps/mapError.js
+++ b/es/maps/mapError.js
@@ -1,0 +1,50 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+var getValidateStatus = exports.getValidateStatus = function getValidateStatus(touched, error, warning, valid) {
+  if (touched) {
+    if (error) return "error";
+    if (warning) return "warning";
+    if (valid) return "success";
+  }
+  return "";
+};
+
+var defaultTo = exports.defaultTo = function defaultTo(value, d) {
+  if (!value && value !== 0) return d;
+  return value;
+};
+
+var mapError = function mapError(_ref) {
+  var _ref$meta = _ref.meta;
+  _ref$meta = _ref$meta === undefined ? {} : _ref$meta;
+
+  var touched = _ref$meta.touched,
+      error = _ref$meta.error,
+      warning = _ref$meta.warning,
+      valid = _ref$meta.valid,
+      inputProps = _objectWithoutProperties(_ref.input, []),
+      props = _objectWithoutProperties(_ref, ["meta", "input"]);
+
+  return _extends({}, props, inputProps, {
+    validateStatus: getValidateStatus(touched, error, warning, valid),
+    help: touched && (error || warning)
+  });
+};
+
+var customMap = exports.customMap = function customMap(customPropsFun) {
+  return function (props) {
+    return [props].reduce(customPropsFun || function (mappedProps) {
+      return mappedProps;
+    }, mapError(props));
+  };
+};
+
+exports.default = mapError;

--- a/es/maps/textFieldMap.js
+++ b/es/maps/textFieldMap.js
@@ -1,0 +1,18 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _mapError = require("./mapError");
+
+exports.default = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _onChange = _ref.input.onChange;
+  return _extends({}, mapProps, {
+    onChange: function onChange(v) {
+      return _onChange(v.nativeEvent.target.value);
+    }
+  });
+});

--- a/lib/components/CheckboxField.js
+++ b/lib/components/CheckboxField.js
@@ -1,0 +1,21 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _checkbox = require("antd/lib/checkbox");
+
+var _checkbox2 = _interopRequireDefault(_checkbox);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+var _eventMap = require("../maps/eventMap");
+
+var _eventMap2 = _interopRequireDefault(_eventMap);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _BaseComponent2.default)(_checkbox2.default, _eventMap2.default);

--- a/lib/components/CheckboxGroupField.js
+++ b/lib/components/CheckboxGroupField.js
@@ -1,0 +1,33 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _checkbox = require("antd/lib/checkbox");
+
+var _checkbox2 = _interopRequireDefault(_checkbox);
+
+var _mapError = require("../maps/mapError");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var CheckboxGroup = _checkbox2.default.Group;
+
+var checkboxGroupMap = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _ref$input = _ref.input,
+      onChange = _ref$input.onChange,
+      _ref$input$value = _ref$input.value,
+      value = _ref$input$value === undefined ? [] : _ref$input$value;
+
+  value = (0, _mapError.defaultTo)(value, []);
+  return _extends({}, mapProps, { onChange: onChange, value: value });
+});
+
+exports.default = (0, _BaseComponent2.default)(CheckboxGroup, checkboxGroupMap);

--- a/lib/components/DatePicker.js
+++ b/lib/components/DatePicker.js
@@ -15,7 +15,7 @@ var _datePicker = require("antd/lib/date-picker");
 
 var _datePicker2 = _interopRequireDefault(_datePicker);
 
-var _mapError = require("./mapError");
+var _mapError = require("../maps/mapError");
 
 var _BaseComponent = require("./BaseComponent");
 

--- a/lib/components/LazyTextField.js
+++ b/lib/components/LazyTextField.js
@@ -1,0 +1,48 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _input = require("antd/lib/input");
+
+var _input2 = _interopRequireDefault(_input);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+var _mapError = require("../maps/mapError");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+// will trigger on change only onBlur
+// usefull for performance reasons
+var bluredFieldMap = function bluredFieldMap(_ref) {
+  var _ref$meta = _ref.meta;
+  _ref$meta = _ref$meta === undefined ? {} : _ref$meta;
+
+  var touched = _ref$meta.touched,
+      error = _ref$meta.error,
+      warning = _ref$meta.warning,
+      valid = _ref$meta.valid,
+      _ref$input = _ref.input,
+      value = _ref$input.value,
+      onChange = _ref$input.onChange,
+      props = _objectWithoutProperties(_ref, ["meta", "input"]);
+
+  return _extends({}, props, {
+    defaultValue: value,
+    onBlur: function onBlur(e) {
+      onChange(e.nativeEvent.target.value);
+    },
+    validateStatus: (0, _mapError.getValidateStatus)(touched, error, warning, valid),
+    help: touched && (error || warning)
+  });
+};
+
+exports.default = (0, _BaseComponent2.default)(_input2.default, bluredFieldMap);

--- a/lib/components/NumberField.js
+++ b/lib/components/NumberField.js
@@ -1,0 +1,21 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _inputNumber = require("antd/lib/input-number");
+
+var _inputNumber2 = _interopRequireDefault(_inputNumber);
+
+var _mapError = require("../maps/mapError");
+
+var _mapError2 = _interopRequireDefault(_mapError);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _BaseComponent2.default)(_inputNumber2.default, _mapError2.default);

--- a/lib/components/RadioField.js
+++ b/lib/components/RadioField.js
@@ -1,0 +1,19 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _eventMap = require("../maps/eventMap");
+
+var _eventMap2 = _interopRequireDefault(_eventMap);
+
+var _MultiSelect = require("./MultiSelect");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _BaseComponent2.default)(_MultiSelect.RadioField, _eventMap2.default);

--- a/lib/components/SelectField.js
+++ b/lib/components/SelectField.js
@@ -1,0 +1,36 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _mapError = require("../maps/mapError");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+var _MultiSelect = require("./MultiSelect");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var selectFieldMap = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _ref$input = _ref.input,
+      onChange = _ref$input.onChange,
+      value = _ref$input.value,
+      multiple = _ref.multiple,
+      options = _ref.options,
+      placeholder = _ref.placeholder;
+
+  if (!placeholder && options && options.length > 0) {
+    value = value ? value : multiple ? [options[0].value] : options[0].value;
+  }
+  if (placeholder) {
+    value = value === "" ? undefined : value;
+  }
+  return _extends({}, mapProps, { dropdownMatchSelectWidth: true, value: value, style: { minWidth: 200 } });
+});
+
+exports.default = (0, _BaseComponent2.default)(_MultiSelect.SelectField, selectFieldMap);

--- a/lib/components/SliderField.js
+++ b/lib/components/SliderField.js
@@ -1,0 +1,36 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _slider = require("antd/lib/slider");
+
+var _slider2 = _interopRequireDefault(_slider);
+
+var _mapError = require("../maps/mapError");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var sliderMap = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _ref$input = _ref.input,
+      onChange = _ref$input.onChange,
+      _ref$input$value = _ref$input.value,
+      value = _ref$input$value === undefined ? 0 : _ref$input$value,
+      range = _ref.range,
+      _ref$min = _ref.min,
+      min = _ref$min === undefined ? 0 : _ref$min,
+      _ref$max = _ref.max,
+      max = _ref$max === undefined ? 100 : _ref$max;
+
+  value = (0, _mapError.defaultTo)(value, range ? [min, max] : 0);
+  return _extends({}, mapProps, { onAfterChange: onChange, value: value });
+});
+
+exports.default = (0, _BaseComponent2.default)(_slider2.default, sliderMap);

--- a/lib/components/SwitchField.js
+++ b/lib/components/SwitchField.js
@@ -1,0 +1,28 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _switch = require("antd/lib/switch");
+
+var _switch2 = _interopRequireDefault(_switch);
+
+var _mapError = require("../maps/mapError");
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var switchMap = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var value = _ref.input.value;
+  return _extends({}, mapProps, {
+    checked: value
+  });
+});
+
+exports.default = (0, _BaseComponent2.default)(_switch2.default, switchMap);

--- a/lib/components/TextAreaField.js
+++ b/lib/components/TextAreaField.js
@@ -1,0 +1,22 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _input = require("antd/lib/input");
+
+var _input2 = _interopRequireDefault(_input);
+
+var _textFieldMap = require("../maps/textFieldMap");
+
+var _textFieldMap2 = _interopRequireDefault(_textFieldMap);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var TextArea = _input2.default.TextArea;
+exports.default = (0, _BaseComponent2.default)(TextArea, _textFieldMap2.default);

--- a/lib/components/TextField.js
+++ b/lib/components/TextField.js
@@ -1,0 +1,21 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _input = require("antd/lib/input");
+
+var _input2 = _interopRequireDefault(_input);
+
+var _textFieldMap = require("../maps/textFieldMap");
+
+var _textFieldMap2 = _interopRequireDefault(_textFieldMap);
+
+var _BaseComponent = require("./BaseComponent");
+
+var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _BaseComponent2.default)(_input2.default, _textFieldMap2.default);

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,8 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.customMap = exports.createComponent = exports.SliderField = exports.NumberField = exports.SwitchField = exports.TextAreaField = exports.TextField = exports.RadioField = exports.CheckboxField = exports.SelectField = exports.LazyTextField = exports.CheckboxGroupField = undefined;
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 var _DatePicker = require("./components/DatePicker");
 
 Object.keys(_DatePicker).forEach(function (key) {
@@ -19,150 +17,63 @@ Object.keys(_DatePicker).forEach(function (key) {
   });
 });
 
-var _checkbox = require("antd/lib/checkbox");
-
-var _checkbox2 = _interopRequireDefault(_checkbox);
-
-var _input = require("antd/lib/input");
-
-var _input2 = _interopRequireDefault(_input);
-
-var _slider = require("antd/lib/slider");
-
-var _slider2 = _interopRequireDefault(_slider);
-
-var _inputNumber = require("antd/lib/input-number");
-
-var _inputNumber2 = _interopRequireDefault(_inputNumber);
-
-var _switch = require("antd/lib/switch");
-
-var _switch2 = _interopRequireDefault(_switch);
-
 var _BaseComponent = require("./components/BaseComponent");
 
 var _BaseComponent2 = _interopRequireDefault(_BaseComponent);
 
-var _MultiSelect = require("./components/MultiSelect");
+var _mapError = require("./maps/mapError");
 
-var _mapError = require("./components/mapError");
+var _CheckboxGroupField2 = require("./components/CheckboxGroupField");
 
-var _mapError2 = _interopRequireDefault(_mapError);
+var _CheckboxGroupField3 = _interopRequireDefault(_CheckboxGroupField2);
+
+var _LazyTextField2 = require("./components/LazyTextField");
+
+var _LazyTextField3 = _interopRequireDefault(_LazyTextField2);
+
+var _SelectField2 = require("./components/SelectField");
+
+var _SelectField3 = _interopRequireDefault(_SelectField2);
+
+var _CheckboxField2 = require("./components/CheckboxField");
+
+var _CheckboxField3 = _interopRequireDefault(_CheckboxField2);
+
+var _RadioField2 = require("./components/RadioField");
+
+var _RadioField3 = _interopRequireDefault(_RadioField2);
+
+var _TextField2 = require("./components/TextField");
+
+var _TextField3 = _interopRequireDefault(_TextField2);
+
+var _TextAreaField2 = require("./components/TextAreaField");
+
+var _TextAreaField3 = _interopRequireDefault(_TextAreaField2);
+
+var _SwitchField2 = require("./components/SwitchField");
+
+var _SwitchField3 = _interopRequireDefault(_SwitchField2);
+
+var _NumberField2 = require("./components/NumberField");
+
+var _NumberField3 = _interopRequireDefault(_NumberField2);
+
+var _SliderField2 = require("./components/SliderField");
+
+var _SliderField3 = _interopRequireDefault(_SliderField2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
-
-var TextArea = _input2.default.TextArea;
-
-var CheckboxGroup = _checkbox2.default.Group;
-
-var defaultTo = function defaultTo(value, d) {
-  if (!value && value !== 0) return d;
-  return value;
-};
-
-var eventMap = (0, _mapError.customMap)(function (mapProps, _ref) {
-  var _onChange = _ref.input.onChange;
-  return _extends({}, mapProps, {
-    onChange: function onChange(v) {
-      return _onChange(v.target.value);
-    }
-  });
-});
-
-var checkboxGroupMap = (0, _mapError.customMap)(function (mapProps, _ref2) {
-  var _ref2$input = _ref2.input,
-      onChange = _ref2$input.onChange,
-      _ref2$input$value = _ref2$input.value,
-      value = _ref2$input$value === undefined ? [] : _ref2$input$value;
-
-  value = defaultTo(value, []);
-  return _extends({}, mapProps, { onChange: onChange, value: value });
-});
-
-var sliderMap = (0, _mapError.customMap)(function (mapProps, _ref3) {
-  var _ref3$input = _ref3.input,
-      onChange = _ref3$input.onChange,
-      _ref3$input$value = _ref3$input.value,
-      value = _ref3$input$value === undefined ? 0 : _ref3$input$value,
-      range = _ref3.range,
-      _ref3$min = _ref3.min,
-      min = _ref3$min === undefined ? 0 : _ref3$min,
-      _ref3$max = _ref3.max,
-      max = _ref3$max === undefined ? 100 : _ref3$max;
-
-  value = defaultTo(value, range ? [min, max] : 0);
-  return _extends({}, mapProps, { onAfterChange: onChange, value: value });
-});
-var textFieldMap = (0, _mapError.customMap)(function (mapProps, _ref4) {
-  var _onChange2 = _ref4.input.onChange;
-  return _extends({}, mapProps, {
-    onChange: function onChange(v) {
-      return _onChange2(v.nativeEvent.target.value);
-    }
-  });
-});
-
-var selectFieldMap = (0, _mapError.customMap)(function (mapProps, _ref5) {
-  var _ref5$input = _ref5.input,
-      onChange = _ref5$input.onChange,
-      value = _ref5$input.value,
-      multiple = _ref5.multiple,
-      options = _ref5.options,
-      placeholder = _ref5.placeholder;
-
-  if (!placeholder && options && options.length > 0) {
-    value = value ? value : multiple ? [options[0].value] : options[0].value;
-  }
-  if (placeholder) {
-    value = value === "" ? undefined : value;
-  }
-  return _extends({}, mapProps, { dropdownMatchSelectWidth: true, value: value, style: { minWidth: 200 } });
-});
-
-var bluredFieldMap = function bluredFieldMap(_ref6) {
-  var _ref6$meta = _ref6.meta;
-  _ref6$meta = _ref6$meta === undefined ? {} : _ref6$meta;
-
-  var touched = _ref6$meta.touched,
-      error = _ref6$meta.error,
-      warning = _ref6$meta.warning,
-      valid = _ref6$meta.valid,
-      _ref6$input = _ref6.input,
-      value = _ref6$input.value,
-      onChange = _ref6$input.onChange,
-      props = _objectWithoutProperties(_ref6, ["meta", "input"]);
-
-  return _extends({}, props, {
-    defaultValue: value,
-    onBlur: function onBlur(e) {
-      onChange(e.nativeEvent.target.value);
-    },
-    validateStatus: (0, _mapError.getValidateStatus)(touched, error, warning, valid),
-    help: touched && (error || warning)
-  });
-};
-
-var switchMap = (0, _mapError.customMap)(function (mapProps, _ref7) {
-  var value = _ref7.input.value;
-  return _extends({}, mapProps, {
-    checked: value
-  });
-});
-
-var CheckboxGroupField = exports.CheckboxGroupField = (0, _BaseComponent2.default)(CheckboxGroup, checkboxGroupMap);
-
-// will trigger on change only onBlur
-// usefull for performance reasons
-var LazyTextField = exports.LazyTextField = (0, _BaseComponent2.default)(_input2.default, bluredFieldMap);
-var SelectField = exports.SelectField = (0, _BaseComponent2.default)(_MultiSelect.SelectField, selectFieldMap);
-var CheckboxField = exports.CheckboxField = (0, _BaseComponent2.default)(_checkbox2.default, eventMap);
-var RadioField = exports.RadioField = (0, _BaseComponent2.default)(_MultiSelect.RadioField, eventMap);
-var TextField = exports.TextField = (0, _BaseComponent2.default)(_input2.default, textFieldMap);
-var TextAreaField = exports.TextAreaField = (0, _BaseComponent2.default)(TextArea, textFieldMap);
-var SwitchField = exports.SwitchField = (0, _BaseComponent2.default)(_switch2.default, switchMap);
-var NumberField = exports.NumberField = (0, _BaseComponent2.default)(_inputNumber2.default, _mapError2.default);
-var SliderField = exports.SliderField = (0, _BaseComponent2.default)(_slider2.default, sliderMap);
+exports.CheckboxGroupField = _CheckboxGroupField3.default;
+exports.LazyTextField = _LazyTextField3.default;
+exports.SelectField = _SelectField3.default;
+exports.CheckboxField = _CheckboxField3.default;
+exports.RadioField = _RadioField3.default;
+exports.TextField = _TextField3.default;
+exports.TextAreaField = _TextAreaField3.default;
+exports.SwitchField = _SwitchField3.default;
+exports.NumberField = _NumberField3.default;
+exports.SliderField = _SliderField3.default;
 exports.createComponent = _BaseComponent2.default;
 exports.customMap = _mapError.customMap;

--- a/lib/maps/eventMap.js
+++ b/lib/maps/eventMap.js
@@ -1,0 +1,18 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _mapError = require("./mapError");
+
+exports.default = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _onChange = _ref.input.onChange;
+  return _extends({}, mapProps, {
+    onChange: function onChange(v) {
+      return _onChange(v.target.value);
+    }
+  });
+});

--- a/lib/maps/mapError.js
+++ b/lib/maps/mapError.js
@@ -1,0 +1,50 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+var getValidateStatus = exports.getValidateStatus = function getValidateStatus(touched, error, warning, valid) {
+  if (touched) {
+    if (error) return "error";
+    if (warning) return "warning";
+    if (valid) return "success";
+  }
+  return "";
+};
+
+var defaultTo = exports.defaultTo = function defaultTo(value, d) {
+  if (!value && value !== 0) return d;
+  return value;
+};
+
+var mapError = function mapError(_ref) {
+  var _ref$meta = _ref.meta;
+  _ref$meta = _ref$meta === undefined ? {} : _ref$meta;
+
+  var touched = _ref$meta.touched,
+      error = _ref$meta.error,
+      warning = _ref$meta.warning,
+      valid = _ref$meta.valid,
+      inputProps = _objectWithoutProperties(_ref.input, []),
+      props = _objectWithoutProperties(_ref, ["meta", "input"]);
+
+  return _extends({}, props, inputProps, {
+    validateStatus: getValidateStatus(touched, error, warning, valid),
+    help: touched && (error || warning)
+  });
+};
+
+var customMap = exports.customMap = function customMap(customPropsFun) {
+  return function (props) {
+    return [props].reduce(customPropsFun || function (mappedProps) {
+      return mappedProps;
+    }, mapError(props));
+  };
+};
+
+exports.default = mapError;

--- a/lib/maps/textFieldMap.js
+++ b/lib/maps/textFieldMap.js
@@ -1,0 +1,18 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _mapError = require("./mapError");
+
+exports.default = (0, _mapError.customMap)(function (mapProps, _ref) {
+  var _onChange = _ref.input.onChange;
+  return _extends({}, mapProps, {
+    onChange: function onChange(v) {
+      return _onChange(v.nativeEvent.target.value);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-antd",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "antd redux form bindings",
   "main": "./lib/index.js",
   "jsnext:main": "./es/index.js",

--- a/src/components/CheckboxField.js
+++ b/src/components/CheckboxField.js
@@ -1,0 +1,5 @@
+import Checkbox from "antd/lib/checkbox";
+import createComponent from "./BaseComponent";
+import eventMap from "../maps/eventMap";
+
+export default createComponent(Checkbox, eventMap);

--- a/src/components/CheckboxGroupField.js
+++ b/src/components/CheckboxGroupField.js
@@ -1,0 +1,15 @@
+import Checkbox from "antd/lib/checkbox";
+import { customMap, defaultTo } from "../maps/mapError";
+import createComponent from "./BaseComponent";
+
+const CheckboxGroup = Checkbox.Group;
+
+const checkboxGroupMap = customMap((mapProps, { input: { onChange, value = [] } }) => {
+  value = defaultTo(value, []);
+  return { ...mapProps, onChange, value };
+});
+
+export default createComponent(
+  CheckboxGroup,
+  checkboxGroupMap
+);

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -1,6 +1,6 @@
 import moment from "moment";
 import DatePicker from "antd/lib/date-picker";
-import {customMap} from "./mapError";
+import {customMap} from "../maps/mapError";
 import createComponent from "./BaseComponent";
 
 const MonthPicker = DatePicker.MonthPicker;

--- a/src/components/LazyTextField.js
+++ b/src/components/LazyTextField.js
@@ -1,0 +1,24 @@
+import Input from "antd/lib/input";
+import createComponent from "./BaseComponent";
+import { getValidateStatus } from "../maps/mapError";
+
+// will trigger on change only onBlur
+// usefull for performance reasons
+const bluredFieldMap = ({
+  meta: {touched, error, warning, valid} = {},
+  input: {value, onChange},
+  ...props
+}) => ({
+  ...props,
+  defaultValue: value,
+  onBlur: e => {
+    onChange(e.nativeEvent.target.value);
+  },
+  validateStatus: getValidateStatus(touched, error, warning, valid),
+  help: touched && (error || warning)
+});
+
+export default createComponent(
+  Input,
+  bluredFieldMap
+);

--- a/src/components/NumberField.js
+++ b/src/components/NumberField.js
@@ -1,0 +1,5 @@
+import InputNumber from "antd/lib/input-number";
+import mapError from "../maps/mapError";
+import createComponent from "./BaseComponent";
+
+export default createComponent(InputNumber, mapError);

--- a/src/components/RadioField.js
+++ b/src/components/RadioField.js
@@ -1,0 +1,5 @@
+import eventMap from "../maps/eventMap";
+import { RadioField as Radio } from "./MultiSelect";
+import createComponent from "./BaseComponent";
+
+export default createComponent(Radio, eventMap);

--- a/src/components/SelectField.js
+++ b/src/components/SelectField.js
@@ -1,0 +1,17 @@
+import { customMap } from "../maps/mapError";
+import createComponent from "./BaseComponent";
+import { SelectField as Select } from "./MultiSelect";
+
+const selectFieldMap = customMap(
+  (mapProps, { input: { onChange, value }, multiple, options, placeholder }) => {
+    if (!placeholder && (options && options.length > 0)) {
+      value = value ? value : multiple ? [options[0].value] : options[0].value;
+    }
+    if (placeholder) {
+      value = value === "" ? undefined : value;
+    }
+    return { ...mapProps, dropdownMatchSelectWidth: true, value, style: { minWidth: 200 } };
+  }
+);
+
+export default createComponent(Select, selectFieldMap);

--- a/src/components/SliderField.js
+++ b/src/components/SliderField.js
@@ -1,0 +1,12 @@
+import Slider from "antd/lib/slider";
+import { customMap, defaultTo } from "../maps/mapError";
+import createComponent from "./BaseComponent";
+
+const sliderMap = customMap(
+  (mapProps, { input: { onChange, value = 0 }, range, min = 0, max = 100 }) => {
+    value = defaultTo(value, range ? [min, max] : 0);
+    return { ...mapProps, onAfterChange: onChange, value };
+  }
+);
+
+export default createComponent(Slider, sliderMap);

--- a/src/components/SwitchField.js
+++ b/src/components/SwitchField.js
@@ -1,0 +1,10 @@
+import Switch from "antd/lib/switch";
+import { customMap } from "../maps/mapError";
+import createComponent from "./BaseComponent";
+
+const switchMap = customMap((mapProps, {input: {value}}) => ({
+  ...mapProps,
+  checked: value
+}));
+
+export default createComponent(Switch, switchMap);

--- a/src/components/TextAreaField.js
+++ b/src/components/TextAreaField.js
@@ -1,0 +1,7 @@
+import Input from "antd/lib/input";
+import textFieldMap from "../maps/textFieldMap";
+import createComponent from "./BaseComponent";
+
+const { TextArea } = Input;
+
+export default createComponent(TextArea, textFieldMap);

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -1,0 +1,5 @@
+import Input from "antd/lib/input";
+import textFieldMap from "../maps/textFieldMap";
+import createComponent from "./BaseComponent";
+
+export default createComponent(Input, textFieldMap);

--- a/src/index.js
+++ b/src/index.js
@@ -1,95 +1,20 @@
-import Checkbox from "antd/lib/checkbox";
-import Input from "antd/lib/input";
-import Slider from "antd/lib/slider";
-import InputNumber from "antd/lib/input-number";
-import Switch from "antd/lib/switch";
 import createComponent from "./components/BaseComponent";
 
-import {
-  RadioField as Radio,
-  SelectField as Select
-} from "./components/MultiSelect";
-import mapError, { customMap, getValidateStatus} from "./components/mapError";
+import { customMap } from "./maps/mapError";
 
-const { TextArea } = Input;
-const CheckboxGroup = Checkbox.Group;
+export CheckboxGroupField from "./components/CheckboxGroupField";
 
-const defaultTo = (value, d) => {
-  if (!value && value !== 0) return d;
-  return value;
-};
+export LazyTextField from "./components/LazyTextField";
 
-const eventMap = customMap((mapProps, { input: { onChange } }) => ({
-  ...mapProps,
-  onChange: v => onChange(v.target.value)
-}));
+export SelectField from "./components/SelectField";
+export CheckboxField from "./components/CheckboxField";
+export RadioField from "./components/RadioField";
+export TextField from "./components/TextField";
+export TextAreaField from "./components/TextAreaField";
+export SwitchField from "./components/SwitchField";
+export NumberField from "./components/NumberField";
+export SliderField from "./components/SliderField";
 
-const checkboxGroupMap = customMap((mapProps, { input: { onChange, value = [] } }) => {
-  value = defaultTo(value, []);
-  return { ...mapProps, onChange, value };
-});
-
-const sliderMap = customMap(
-  (mapProps, { input: { onChange, value = 0 }, range, min = 0, max = 100 }) => {
-    value = defaultTo(value, range ? [min, max] : 0);
-    return { ...mapProps, onAfterChange: onChange, value };
-  }
-);
-const textFieldMap = customMap((mapProps, { input: { onChange } }) => ({
-  ...mapProps,
-  onChange: v => onChange(v.nativeEvent.target.value)
-}));
-
-const selectFieldMap = customMap(
-  (mapProps, { input: { onChange, value }, multiple, options, placeholder }) => {
-    if (!placeholder && (options && options.length > 0)) {
-      value = value ? value : multiple ? [options[0].value] : options[0].value;
-    }
-    if (placeholder) {
-      value = value === "" ? undefined : value;
-    }
-    return { ...mapProps, dropdownMatchSelectWidth: true, value, style: { minWidth: 200 } };
-  }
-);
-
-const bluredFieldMap = ({
-    meta: {touched, error, warning, valid} = {},
-    input: {value, onChange},
-    ...props
-  }) => ({
-    ...props,
-    defaultValue: value,
-    onBlur: e => {
-      onChange(e.nativeEvent.target.value);
-    },
-    validateStatus: getValidateStatus(touched, error, warning, valid),
-    help: touched && (error || warning)
-  });
-
-const switchMap = customMap((mapProps, {input: {value}}) => ({
-  ...mapProps,
-  checked: value
-}));
-
-export const CheckboxGroupField = createComponent(
-  CheckboxGroup,
-  checkboxGroupMap
-);
-
-// will trigger on change only onBlur
-// usefull for performance reasons
-export const LazyTextField = createComponent(
-  Input,
-  bluredFieldMap
-);
-export const SelectField = createComponent(Select, selectFieldMap);
-export const CheckboxField = createComponent(Checkbox, eventMap);
-export const RadioField = createComponent(Radio, eventMap);
-export const TextField = createComponent(Input, textFieldMap);
-export const TextAreaField = createComponent(TextArea, textFieldMap);
-export const SwitchField = createComponent(Switch, switchMap);
-export const NumberField = createComponent(InputNumber, mapError);
-export const SliderField = createComponent(Slider, sliderMap);
 export * from "./components/DatePicker";
 
 export { createComponent, customMap };

--- a/src/maps/eventMap.js
+++ b/src/maps/eventMap.js
@@ -1,0 +1,6 @@
+import { customMap } from "./mapError";
+
+export default customMap((mapProps, { input: { onChange } }) => ({
+  ...mapProps,
+  onChange: v => onChange(v.target.value)
+}));

--- a/src/maps/mapError.js
+++ b/src/maps/mapError.js
@@ -7,6 +7,11 @@ export const getValidateStatus = (touched, error, warning, valid) => {
   return "";
 };
 
+export const defaultTo = (value, d) => {
+  if (!value && value !== 0) return d;
+  return value;
+};
+
 const mapError = ({
   meta: { touched, error, warning, valid } = {},
   input: { ...inputProps },

--- a/src/maps/textFieldMap.js
+++ b/src/maps/textFieldMap.js
@@ -1,0 +1,6 @@
+import { customMap } from "./mapError";
+
+export default customMap((mapProps, { input: { onChange } }) => ({
+  ...mapProps,
+  onChange: v => onChange(v.nativeEvent.target.value)
+}));


### PR DESCRIPTION
Allows for individual field files to be imported, cutting off large unneeded portions of Ant Design.

For example, I don't use a DatePicker, which means I don't have to import the entirety of Moment.