### PR TITLE
Updated getValidateStatus() to return undefined instead of empty string

### DIFF
--- a/es/maps/mapError.js
+++ b/es/maps/mapError.js
@@ -22,7 +22,7 @@ var getValidateStatus = function getValidateStatus(touched, error, warning, vali
     if (valid) return "success";
   }
 
-  return "";
+  return undefined;
 };
 
 exports.getValidateStatus = getValidateStatus;

--- a/lib/maps/mapError.js
+++ b/lib/maps/mapError.js
@@ -22,7 +22,7 @@ var getValidateStatus = function getValidateStatus(touched, error, warning, vali
     if (valid) return "success";
   }
 
-  return "";
+  return undefined;
 };
 
 exports.getValidateStatus = getValidateStatus;

--- a/src/maps/mapError.js
+++ b/src/maps/mapError.js
@@ -4,7 +4,7 @@ export const getValidateStatus = (touched, error, warning, valid) => {
     if (warning) return "warning";
     if (valid) return "success";
   }
-  return "";
+  return undefined;
 };
 
 export const defaultTo = (value, d) => {


### PR DESCRIPTION
This gets rid of an invalid prop error when using newest redux-form.
```
Warning: Failed prop type: Invalid prop `validateStatus` of value `` supplied to `FormItem`, expected one of ["success","warning","error","validating"].
```