### PR TITLE
Convert undefined to null to fix the allowClear option of Select fields

### DIFF
--- a/es/components/SelectField.js
+++ b/es/components/SelectField.js
@@ -19,7 +19,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 var selectFieldMap = (0, _mapError.customMap)(function (mapProps, _ref) {
   var _ref$input = _ref.input,
-      onChange = _ref$input.onChange,
+      _onChange = _ref$input.onChange,
       value = _ref$input.value,
       multiple = _ref.multiple,
       options = _ref.options,
@@ -34,6 +34,9 @@ var selectFieldMap = (0, _mapError.customMap)(function (mapProps, _ref) {
   }
 
   return _objectSpread({}, mapProps, {
+    onChange: function onChange(value) {
+      return value === undefined ? _onChange(null) : _onChange(value);
+    },
     dropdownMatchSelectWidth: true,
     value: value,
     style: {

--- a/lib/components/SelectField.js
+++ b/lib/components/SelectField.js
@@ -19,7 +19,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 var selectFieldMap = (0, _mapError.customMap)(function (mapProps, _ref) {
   var _ref$input = _ref.input,
-      onChange = _ref$input.onChange,
+      _onChange = _ref$input.onChange,
       value = _ref$input.value,
       multiple = _ref.multiple,
       options = _ref.options,
@@ -34,6 +34,9 @@ var selectFieldMap = (0, _mapError.customMap)(function (mapProps, _ref) {
   }
 
   return _objectSpread({}, mapProps, {
+    onChange: function onChange(value) {
+      return value === undefined ? _onChange(null) : _onChange(value);
+    },
     dropdownMatchSelectWidth: true,
     value: value,
     style: {

--- a/src/components/SelectField.js
+++ b/src/components/SelectField.js
@@ -10,7 +10,13 @@ const selectFieldMap = customMap(
     if (placeholder) {
       value = value === "" ? undefined : value;
     }
-    return { ...mapProps, dropdownMatchSelectWidth: true, value, style: { minWidth: 200 } };
+    return {
+        ...mapProps,
+        onChange: value => value === undefined ? onChange(null) : onChange(value),
+        dropdownMatchSelectWidth: true,
+        value,
+        style: { minWidth: 200 }
+    };
   }
 );
 

--- a/stories/TextInput.js
+++ b/stories/TextInput.js
@@ -168,6 +168,7 @@ storiesOf("TextField", module)
           mode={select("mode", modes)}
           allowClear={boolean("allowClear", false)}
           notFoundContent={text("notFoundContent", "not found")}
+          placeholder={text("placeholder", "nothing selected")}
           tokenSeparators={text("tokenSeparators", ",")}
         />
       </div>


### PR DESCRIPTION
When clearing a Select field, `antd` calls the `onChange` handler with `undefined`. `redux-form` does not trigger a change in value for that case.

When passing `null` instead, the value is actually reset. You can see the updated example in the storybook, it now correctly shows the Placeholder.